### PR TITLE
Update game main menu

### DIFF
--- a/.github/workflows/buildExe.yml
+++ b/.github/workflows/buildExe.yml
@@ -23,46 +23,22 @@ jobs:
         install: >-
           mingw-w64-x86_64-gcc
           mingw-w64-x86_64-ncurses
-          mingw-w64-x86_64-ncurses-devel
           make
           
-    - name: Create compatibility layer for ncurses
+    - name: Find ncurses headers and create compatibility layer
       shell: msys2 {0}
       run: |
-        mkdir -p ~/local/include ~/local/lib
+        echo "Finding ncurses.h..."
+        echo "#include <ncurses/ncurses.h>" > /mingw64/include/ncurses.h
         
-        echo "Creating symbolic links for ncurses headers..."
-        cp -r /mingw64/include/ncurses* ~/local/include/
+        mkdir -p include
+        echo "#include <ncurses/ncurses.h>" > include/ncurses.h
         
-        if [ ! -f ~/local/include/ncurses.h ]; then
-          echo "#include <ncursesw/ncurses.h>" > ~/local/include/ncurses.h
-          echo "Created compatibility ncurses.h header"
-        fi
+        # Create home directory compatibility headers too
+        mkdir -p ~/local/include
+        echo "#include <ncurses/ncurses.h>" > ~/local/include/ncurses.h
         
-        echo "Copying ncurses libraries..."
-        cp -r /mingw64/lib/libncursesw* ~/local/lib/
-        ln -sf ~/local/lib/libncursesw.a ~/local/lib/libncurses.a
-        ln -sf ~/local/lib/libncursesw.dll.a ~/local/lib/libncurses.dll.a
-        
-        echo "Checking compatibility layer..."
-        ls -la ~/local/include/
-        ls -la ~/local/lib/
-        
-    - name: Fix Makefile 
-      shell: msys2 {0}
-      run: |
-        echo "Removing calls to installNcurses.sh from Makefile..."
-        cp Makefile Makefile.bak
-        sed -i '/installNcurses.sh/d' Makefile
-        
-        echo "Updating Makefile for Windows target..."
-        sed -i 's/$(BIN_DIR)\\\\main/$(BIN_DIR)\\\\main.exe/g' Makefile
-        
-        echo "Updating Makefile to use ncursesw library..."
-        sed -i 's/-lncurses/-lncursesw/g' Makefile
-        
-        echo "Modified Makefile:"
-        cat Makefile
+        echo "Created ncurses.h compatibility headers"
     
     - name: Create build directories
       shell: msys2 {0}
@@ -71,27 +47,27 @@ jobs:
     - name: Build application
       shell: msys2 {0}
       run: |
-        echo "Building application..."
+        sed -i 's/TARGET = $(BIN_DIR)\/main/TARGET = $(BIN_DIR)\/main.exe/g' Makefile
+        
+        export CXXFLAGS="-I/mingw64/include"
+        
+        sed -i 's/-lncurses/-lncursesw/g' Makefile
+        
+        echo "Building with modified settings..."
         make
       
     - name: Package executable with dependencies
       shell: msys2 {0}
       run: |
-        if [ -f bin/main.exe ]; then
-          mkdir -p package
-          cp bin/main.exe package/game.exe
-          cp /mingw64/bin/libncursesw*.dll package/
-          cp /mingw64/bin/libgcc_s_seh-1.dll package/
-          cp /mingw64/bin/libstdc++-6.dll package/
-          cp /mingw64/bin/libwinpthread-1.dll package/
-          cp /mingw64/bin/libiconv*.dll package/
-          cp /mingw64/bin/libintl*.dll package/
-          echo "Package created successfully!"
-        else
-          echo "Error: Executable not found!"
-          ls -la bin/
-          exit 1
-        fi
+        mkdir -p package
+        cp bin/main.exe package/game.exe
+        cp /mingw64/bin/libncursesw*.dll package/
+        cp /mingw64/bin/libgcc_s_seh-1.dll package/
+        cp /mingw64/bin/libstdc++-6.dll package/
+        cp /mingw64/bin/libwinpthread-1.dll package/
+        
+        cp /mingw64/bin/libiconv*.dll package/
+        cp /mingw64/bin/libintl*.dll package/
     
     - name: Upload Windows executable
       uses: actions/upload-artifact@v4

--- a/.github/workflows/buildExe.yml
+++ b/.github/workflows/buildExe.yml
@@ -25,16 +25,28 @@ jobs:
           mingw-w64-x86_64-ncurses
           make
           
-    - name: Find ncurses headers and create compatibility layer
+    - name: Fix Makefile to avoid ncurses installation loop
       shell: msys2 {0}
       run: |
-        echo "Finding ncurses.h..."
-        echo "#include <ncurses/ncurses.h>" > /mingw64/include/ncurses.h
+        echo "Removing calls to installNcurses.sh from Makefile..."
+        cp Makefile Makefile.bak
         
-        mkdir -p include
-        echo "#include <ncurses/ncurses.h>" > include/ncurses.h
+        sed -i '/installNcurses.sh/d' Makefile
         
-        echo "Created ncurses.h symlink"
+        echo "Updating Makefile for Windows target..."
+        sed -i 's/$(BIN_DIR)\\\\main/$(BIN_DIR)\\\\main.exe/g' Makefile
+        
+        echo "Updating Makefile to use ncursesw library..."
+        sed -i 's/-lncurses/-lncursesw/g' Makefile
+
+        echo "Updating Makefile ncurses library path..."
+        sed -i 's|-L~/local/lib|-L/mingw64/lib|g' Makefile
+        
+        echo "Adding system include paths..."
+        sed -i 's|-I~/local/include|-I/mingw64/include|g' Makefile
+        
+        echo "Modified Makefile:"
+        cat Makefile
     
     - name: Create build directories
       shell: msys2 {0}
@@ -43,15 +55,6 @@ jobs:
     - name: Build application
       shell: msys2 {0}
       run: |
-        echo "Updating Makefile for Windows target..."
-        sed -i 's/$(BIN_DIR)\\main/$(BIN_DIR)\\main.exe/g' Makefile
-        
-        echo "Updating Makefile to use ncursesw library..."
-        sed -i 's/-lncurses/-lncursesw/g' Makefile
-
-        echo "Updating Makefile ncurses library path..."
-        sed -i 's|-L~/local/lib|-L/mingw64/lib|g' Makefile 
-
         echo "Building application..."
         make
       

--- a/.github/workflows/buildExe.yml
+++ b/.github/workflows/buildExe.yml
@@ -23,14 +23,36 @@ jobs:
         install: >-
           mingw-w64-x86_64-gcc
           mingw-w64-x86_64-ncurses
+          mingw-w64-x86_64-ncurses-devel
           make
           
-    - name: Fix Makefile to avoid ncurses installation loop
+    - name: Create compatibility layer for ncurses
+      shell: msys2 {0}
+      run: |
+        mkdir -p ~/local/include ~/local/lib
+        
+        echo "Creating symbolic links for ncurses headers..."
+        cp -r /mingw64/include/ncurses* ~/local/include/
+        
+        if [ ! -f ~/local/include/ncurses.h ]; then
+          echo "#include <ncursesw/ncurses.h>" > ~/local/include/ncurses.h
+          echo "Created compatibility ncurses.h header"
+        fi
+        
+        echo "Copying ncurses libraries..."
+        cp -r /mingw64/lib/libncursesw* ~/local/lib/
+        ln -sf ~/local/lib/libncursesw.a ~/local/lib/libncurses.a
+        ln -sf ~/local/lib/libncursesw.dll.a ~/local/lib/libncurses.dll.a
+        
+        echo "Checking compatibility layer..."
+        ls -la ~/local/include/
+        ls -la ~/local/lib/
+        
+    - name: Fix Makefile 
       shell: msys2 {0}
       run: |
         echo "Removing calls to installNcurses.sh from Makefile..."
         cp Makefile Makefile.bak
-        
         sed -i '/installNcurses.sh/d' Makefile
         
         echo "Updating Makefile for Windows target..."
@@ -38,17 +60,6 @@ jobs:
         
         echo "Updating Makefile to use ncursesw library..."
         sed -i 's/-lncurses/-lncursesw/g' Makefile
-        
-        echo "Finding where ncurses.h is located..."
-        find /mingw64 -name ncurses.h
-        
-        echo "Updating compiler flags directly..."
-        sed -i 's/g++ -std=c++14/g++ -std=c++14 -I\/mingw64\/include/g' Makefile
-        
-        sed -i 's|-I~/local/include|-I/mingw64/include|g' Makefile
-        sed -i 's|-L~/local/lib|-L/mingw64/lib|g' Makefile
-        
-        grep -q "CXXFLAGS" Makefile || echo "CXXFLAGS = -I/mingw64/include" >> Makefile
         
         echo "Modified Makefile:"
         cat Makefile
@@ -66,15 +77,21 @@ jobs:
     - name: Package executable with dependencies
       shell: msys2 {0}
       run: |
-        mkdir -p package
-        cp bin/main.exe package/game.exe
-        cp /mingw64/bin/libncursesw*.dll package/
-        cp /mingw64/bin/libgcc_s_seh-1.dll package/
-        cp /mingw64/bin/libstdc++-6.dll package/
-        cp /mingw64/bin/libwinpthread-1.dll package/
-        
-        cp /mingw64/bin/libiconv*.dll package/
-        cp /mingw64/bin/libintl*.dll package/
+        if [ -f bin/main.exe ]; then
+          mkdir -p package
+          cp bin/main.exe package/game.exe
+          cp /mingw64/bin/libncursesw*.dll package/
+          cp /mingw64/bin/libgcc_s_seh-1.dll package/
+          cp /mingw64/bin/libstdc++-6.dll package/
+          cp /mingw64/bin/libwinpthread-1.dll package/
+          cp /mingw64/bin/libiconv*.dll package/
+          cp /mingw64/bin/libintl*.dll package/
+          echo "Package created successfully!"
+        else
+          echo "Error: Executable not found!"
+          ls -la bin/
+          exit 1
+        fi
     
     - name: Upload Windows executable
       uses: actions/upload-artifact@v4

--- a/.github/workflows/buildExe.yml
+++ b/.github/workflows/buildExe.yml
@@ -72,3 +72,8 @@ jobs:
         path: package/
         retention-days: 14
         if-no-files-found: error
+
+    - name: Add artifact link annotation
+      if: always()
+      run: |
+        echo "::notice::Windows executable artifact can be downloaded from this workflow run: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/buildExe.yml
+++ b/.github/workflows/buildExe.yml
@@ -38,12 +38,17 @@ jobs:
         
         echo "Updating Makefile to use ncursesw library..."
         sed -i 's/-lncurses/-lncursesw/g' Makefile
-
-        echo "Updating Makefile ncurses library path..."
+        
+        echo "Finding where ncurses.h is located..."
+        find /mingw64 -name ncurses.h
+        
+        echo "Updating compiler flags directly..."
+        sed -i 's/g++ -std=c++14/g++ -std=c++14 -I\/mingw64\/include/g' Makefile
+        
+        sed -i 's|-I~/local/include|-I/mingw64/include|g' Makefile
         sed -i 's|-L~/local/lib|-L/mingw64/lib|g' Makefile
         
-        echo "Adding system include paths..."
-        sed -i 's|-I~/local/include|-I/mingw64/include|g' Makefile
+        grep -q "CXXFLAGS" Makefile || echo "CXXFLAGS = -I/mingw64/include" >> Makefile
         
         echo "Modified Makefile:"
         cat Makefile

--- a/.github/workflows/buildExe.yml
+++ b/.github/workflows/buildExe.yml
@@ -43,13 +43,16 @@ jobs:
     - name: Build application
       shell: msys2 {0}
       run: |
-        sed -i 's/TARGET = $(BIN_DIR)\/main/TARGET = $(BIN_DIR)\/main.exe/g' Makefile
+        echo "Updating Makefile for Windows target..."
+        sed -i 's/TARGET = $(BIN_DIR)\\/main/TARGET = $(BIN_DIR)\\/main.exe/g' Makefile
         
-        export CXXFLAGS="-I/mingw64/include"
-        
+        echo "Updating Makefile to use ncursesw library..."
         sed -i 's/-lncurses/-lncursesw/g' Makefile
-        
-        echo "Building with modified settings..."
+
+        echo "Updating Makefile ncurses library path..."
+        sed -i 's|-L~/local/lib|-L/mingw64/lib|g' Makefile 
+
+        echo "Building application..."
         make
       
     - name: Package executable with dependencies

--- a/.github/workflows/buildExe.yml
+++ b/.github/workflows/buildExe.yml
@@ -11,6 +11,8 @@ jobs:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     name: Build Windows Executable
     runs-on: windows-latest
+    permissions:
+      pull-requests: write
 
     steps:
     - name: Checkout repository
@@ -77,3 +79,51 @@ jobs:
       if: always()
       run: |
         echo "::notice::Windows executable artifact can be downloaded from this workflow run: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
+    - name: Post artifact link comment on PR
+      if: github.event_name == 'pull_request'
+      uses: actions/github-script@v7
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        script: |
+          const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+          const commitSha = context.sha;
+          const shortSha = commitSha.slice(0, 7);
+          const commitUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/commit/${commitSha}`;
+          const commitMessage = (context.payload.head_commit && context.payload.head_commit.message) || 'N/A';
+          const actor = context.actor;
+          const timestamp = new Date().toISOString(); // ISO 8601 format includes seconds
+
+          const commentMarker = "<!-- GITHUB_ACTIONS_ARTIFACT_COMMENT -->";
+          const commentBody = `Build successful. Download Windows executable from [workflow run page](${runUrl}).\n\nBuilt on: ${timestamp} on Commit [${shortSha}](${commitUrl}) by ${actor}: ${commitMessage}\n\n${commentMarker}`;
+
+          const { data: comments } = await github.rest.issues.listComments({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: context.issue.number,
+          });
+
+          const previousComment = comments.find(comment =>
+            comment.user.login === 'github-actions[bot]' &&
+            comment.body.includes(commentMarker)
+          );
+
+          if (previousComment) {
+            // Update the existing comment
+            await github.rest.issues.updateComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: previousComment.id,
+              body: commentBody
+            });
+            console.log(`Updated comment ${previousComment.id}`);
+          } else {
+            // Create a new comment
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: commentBody
+            });
+            console.log('Created a new comment');
+          }

--- a/.github/workflows/buildExe.yml
+++ b/.github/workflows/buildExe.yml
@@ -11,51 +11,48 @@ jobs:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     name: Build Windows Executable
     runs-on: windows-latest
-    
+
     steps:
     - name: Checkout repository
       uses: actions/checkout@v3
-      
+
     - name: Setup MSYS2
       uses: msys2/setup-msys2@v2
       with:
         update: true
-        install: >-
+        install: >
+          git
           mingw-w64-x86_64-gcc
           mingw-w64-x86_64-ncurses
           make
-          
+
     - name: Find ncurses headers and create compatibility layer
       shell: msys2 {0}
       run: |
         echo "Finding ncurses.h..."
         echo "#include <ncurses/ncurses.h>" > /mingw64/include/ncurses.h
-        
+
         mkdir -p include
         echo "#include <ncurses/ncurses.h>" > include/ncurses.h
-        
-        # Create home directory compatibility headers too
+
         mkdir -p ~/local/include
         echo "#include <ncurses/ncurses.h>" > ~/local/include/ncurses.h
-        
+
         echo "Created ncurses.h compatibility headers"
-    
+
     - name: Create build directories
       shell: msys2 {0}
       run: mkdir -p bin build
-      
+
     - name: Build application
       shell: msys2 {0}
       run: |
         sed -i 's/TARGET = $(BIN_DIR)\/main/TARGET = $(BIN_DIR)\/main.exe/g' Makefile
-        
         export CXXFLAGS="-I/mingw64/include"
-        
         sed -i 's/-lncurses/-lncursesw/g' Makefile
-        
         echo "Building with modified settings..."
         make
-      
+
     - name: Package executable with dependencies
       shell: msys2 {0}
       run: |
@@ -65,10 +62,9 @@ jobs:
         cp /mingw64/bin/libgcc_s_seh-1.dll package/
         cp /mingw64/bin/libstdc++-6.dll package/
         cp /mingw64/bin/libwinpthread-1.dll package/
-        
         cp /mingw64/bin/libiconv*.dll package/
         cp /mingw64/bin/libintl*.dll package/
-    
+
     - name: Upload Windows executable
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/buildExe.yml
+++ b/.github/workflows/buildExe.yml
@@ -44,7 +44,7 @@ jobs:
       shell: msys2 {0}
       run: |
         echo "Updating Makefile for Windows target..."
-        sed -i 's/TARGET = $(BIN_DIR)\\/main/TARGET = $(BIN_DIR)\\/main.exe/g' Makefile
+        sed -i 's/$(BIN_DIR)\\main/$(BIN_DIR)\\main.exe/g' Makefile
         
         echo "Updating Makefile to use ncursesw library..."
         sed -i 's/-lncurses/-lncursesw/g' Makefile

--- a/include/game.h
+++ b/include/game.h
@@ -1,32 +1,54 @@
-#pragma once
+#ifndef GAME_H
+#define GAME_H
 
 #include <ncurses.h>
-#include <string>
 #include <vector>
+#include <string>
+
+// Define the GameState enum before the class uses it
+enum class GameState {
+    MAIN_MENU,
+    DIFFICULTY_SELECT,
+    IN_GAME,
+    LOADING,
+    EXITING
+};
 
 class Game {
+public:
+    Game();
+    ~Game();
+    void run();
+
 private:
-    WINDOW* mainWindow;
-    int height;
-    int width;
+    WINDOW *mainWindow;
+    int height, width;
     int menuHighlight;
     std::vector<std::string> menuItems;
-    const int MIN_HEIGHT = 20;
-    const int MIN_WIDTH = 80;
 
-public:
-    // Constructor initializes ncurses and create main window
-    Game();
+    // Added Members
+    GameState current_state; // Current state of the game
+    int difficultyHighlight; // Currently selected difficulty option index
+    std::vector<std::string> difficultyItems; // Difficulty level names
 
-    // Destructor deletes game instance when exits main
-    ~Game();
-
+    // Display Functions
     void displayMenu();
+    void displayDifficultyMenu();
     void displayContent(const std::string& text);
     void display_size_warning();
+
+    // Game Logic Functions
+    void newGame(int difficulty);
+    void load();
+
+    // Input Handlers
+    void handleMainMenuInput(int choice);
+    void handleDifficultyInput(int choice);
+
+    // Utility Functions
     bool checkSize();
     void waitForResize();
-    void newGame();
-    void load();
-    void run();
+
 };
+
+#endif

--- a/include/game.h
+++ b/include/game.h
@@ -35,19 +35,18 @@ private:
     void displayMenu();
     void displayDifficultyMenu();
     void displayContent(const std::string& text);
-    void display_size_warning();
+    void display_size_warning(int &newHeight, int &newWidth);
     void displayStats(); // Changed load() to displayStats()
-
+    
     // Game Logic Functions
     void newGame(int difficulty);
-
+    
     // Input Handlers
     void handleMainMenuInput(int choice);
     void handleDifficultyInput(int choice);
-
+    
     // Utility Functions
-    bool checkSize();
-    void waitForResize();
+    void ask_for_resize();
 
 };
 

--- a/include/game.h
+++ b/include/game.h
@@ -9,8 +9,8 @@
 enum class GameState {
     MAIN_MENU,
     DIFFICULTY_SELECT,
+    STATS,
     IN_GAME,
-    LOADING,
     EXITING
 };
 
@@ -36,10 +36,10 @@ private:
     void displayDifficultyMenu();
     void displayContent(const std::string& text);
     void display_size_warning();
+    void displayStats(); // Changed load() to displayStats()
 
     // Game Logic Functions
     void newGame(int difficulty);
-    void load();
 
     // Input Handlers
     void handleMainMenuInput(int choice);

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1,117 +1,354 @@
 #include "../include/game.h"
+#include <ncurses.h>
+#include <string.h>
+#include <vector>
+#include <string>
+#include <algorithm>
+
+// Constants
+const int MIN_HEIGHT = 25;
+const int MIN_WIDTH = 80;
 
 // Constructor initializes ncurses and create main window
-Game::Game() : menuHighlight(0), menuItems{"New Game", "Load", "Exit"} {
+Game::Game() : menuHighlight(0), menuItems{"Start", "Load", "Exit"}, current_state(GameState::MAIN_MENU), difficultyHighlight(0), difficultyItems{"Easy", "Medium", "Hard"} {
     initscr();             // Initialize ncurses
     cbreak();              // Disable line buffering
     noecho();              // Don't show input
     curs_set(0);           // Don't show curses
-    keypad(stdscr, TRUE);  // Enable special keys
+    start_color();         // Enable color usage
+    keypad(stdscr, TRUE);  // Enable special keys for stdscr initially
+
+    // Initialize color pairs
+    init_pair(1, COLOR_YELLOW, COLOR_BLACK);
+    init_pair(2, COLOR_CYAN, COLOR_BLACK);
 
     // Get screen size
     getmaxyx(stdscr, height, width);
 
+    // Check initial size
+    if (!checkSize()) {
+         display_size_warning();
+    }
+
     // Create the main window
     mainWindow = newwin(height, width, 0, 0);
+    keypad(mainWindow, TRUE); // Enable special keys for the main window specifically
     box(mainWindow, 0, 0);
-    refresh();
-    wrefresh(mainWindow);
+    refresh(); // Refresh stdscr
+    wrefresh(mainWindow); // Refresh the window
 }
 
-// Destructor deletes game instance when exits main
+// Destructor
 Game::~Game() {
     delwin(mainWindow);
     endwin();
 }
 
+// Display Functions
+
 void Game::displayMenu() {
     werase(mainWindow);
     box(mainWindow, 0, 0);
 
-    for (size_t i = 0; i < menuItems.size(); ++i) {
+    // Show title in the center
+    const char* title = "Rebirth: Me Delivering Keeta in Doomsday";
+    int titleLen = strlen(title);
+    wattron(mainWindow, COLOR_PAIR(1) | A_BOLD);
+    mvwprintw(mainWindow, 3, std::max(1, (width - titleLen) / 2), "%s", title); // Gets centered
+    wattroff(mainWindow, COLOR_PAIR(1) | A_BOLD);
+
+    // These lines calculate the X positions for the menu and description columns
+    // The menu will be on the left, and the description on the right.
+    int menuX = std::max(1, width * 3 / 10);
+    int descX = std::max(menuX + 15, width * 6 / 10);
+
+    // Menu items
+    int startY = height / 2 - menuItems.size() / 2;
+    for (int i = 0; i < menuItems.size(); ++i) {
         if (i == menuHighlight) {
             wattron(mainWindow, A_REVERSE);
         }
-        mvwprintw(mainWindow, height / 2 - menuItems.size() / 2 + i,
-                  width / 2 - menuItems[i].length() / 2, menuItems[i].c_str());
-        wattroff(mainWindow, A_REVERSE);
+        mvwprintw(mainWindow, startY + i, menuX, "%s", menuItems[i].c_str());
+        if (i == menuHighlight) {
+            wattroff(mainWindow, A_REVERSE);
+        }
     }
+
+    // Instructions
+    int rightY = startY;
+    wattron(mainWindow, COLOR_PAIR(2)); // Change the color pair accordingly @Art&Design
+
+    mvwprintw(mainWindow, rightY++, descX, "-------------------------");
+    mvwprintw(mainWindow, rightY++, descX, "Welcome, Player!");
+    mvwprintw(mainWindow, rightY++, descX, " ");
+    mvwprintw(mainWindow, rightY++, descX, "Navigate: UP/DOWN Arrows");
+    mvwprintw(mainWindow, rightY++, descX, "Select:   ENTER");
+    mvwprintw(mainWindow, rightY++, descX, " ");
+    mvwprintw(mainWindow, rightY++, descX, "Select 'Start' to begin");
+    mvwprintw(mainWindow, rightY++, descX, "your perilous journey.");
+    mvwprintw(mainWindow, rightY++, descX, "-------------------------");
+    wattroff(mainWindow, COLOR_PAIR(2));
+
+    wrefresh(mainWindow);
+}
+
+void Game::displayDifficultyMenu() {
+    werase(mainWindow);
+    box(mainWindow, 0, 0);
+
+    // Secondary Title
+    const char* title = "Select Difficulty";
+    int titleLen = strlen(title);
+    wattron(mainWindow, COLOR_PAIR(1) | A_BOLD);
+    mvwprintw(mainWindow, 3, std::max(1, (width - titleLen) / 2), "%s", title);
+    wattroff(mainWindow, COLOR_PAIR(1) | A_BOLD);
+
+    // Column calculations same as above
+    int menuX = std::max(1, width * 3 / 10);
+    int descX = std::max(menuX + 15, width * 6 / 10);
+
+    // Difficulty Options
+    int startY = height / 2 - difficultyItems.size() / 2;
+    for (int i = 0; i < difficultyItems.size(); ++i) {
+        if (i == difficultyHighlight) {
+            wattron(mainWindow, A_REVERSE);
+        }
+        mvwprintw(mainWindow, startY + i, menuX, "%s", difficultyItems[i].c_str());
+        if (i == difficultyHighlight) {
+            wattroff(mainWindow, A_REVERSE);
+        }
+    }
+
+    // Diff Details
+    int rightY = startY - 2;
+    wattron(mainWindow, COLOR_PAIR(2));
+    mvwprintw(mainWindow, rightY++, descX, "-------------------------");
+
+    std::string map_size, packages, obstacles, desc;
+    switch (difficultyHighlight) {
+        // EZ
+        case 0:
+            map_size = "9x9"; packages = "3"; obstacles = "5";
+            desc = "A gentler start.";
+            break;
+        // Medium
+        case 1:
+            map_size = "11x11"; packages = "4"; obstacles = "6";
+            desc = "A standard challenge.";
+            break;
+        // Hard
+        case 2:
+            map_size = "13x13"; packages = "5"; obstacles = "7";
+            desc = "For the seasoned courier.";
+            break;
+    }
+
+    mvwprintw(mainWindow, rightY++, descX, "Difficulty: %s", difficultyItems[difficultyHighlight].c_str());
+    mvwprintw(mainWindow, rightY++, descX, "Description: %s", desc.c_str());
+    mvwprintw(mainWindow, rightY++, descX, " ");
+    mvwprintw(mainWindow, rightY++, descX, "Map Size:    %s", map_size.c_str());
+    mvwprintw(mainWindow, rightY++, descX, "Packages:    %s", packages.c_str());
+    mvwprintw(mainWindow, rightY++, descX, "Obstacles:   %s", obstacles.c_str());
+    mvwprintw(mainWindow, rightY++, descX, " ");
+    mvwprintw(mainWindow, rightY++, descX, "Stamina: 200 start, +50/lvl");
+    mvwprintw(mainWindow, rightY++, descX, "Score based on completion,");
+    mvwprintw(mainWindow, rightY++, descX, "time, and packages.");
+    mvwprintw(mainWindow, rightY++, descX, "-------------------------");
+    wattroff(mainWindow, COLOR_PAIR(2));
+
+    // Bottom Instructions
+    const char* instructions = "UP/DOWN to change, ENTER to confirm, ESC to go back.";
+    int instrX = std::max(1, (width - (int)strlen(instructions)) / 2); // Center these texts
+    mvwprintw(mainWindow, height - 3, instrX, "%s", instructions);
 
     wrefresh(mainWindow);
 }
 
 void Game::displayContent(const std::string& text) {
-    werase(mainWindow);
-    box(mainWindow, 0, 0);
-    mvwprintw(mainWindow, height / 2, width / 2 - text.length() / 2, text.c_str());
-    wgetch(mainWindow);
+     werase(mainWindow);
+     box(mainWindow, 0, 0);
+     mvwprintw(mainWindow, height / 2, (width - text.length()) / 2, "%s", text.c_str());
+     wrefresh(mainWindow);
+     wgetch(mainWindow);
 }
 
 void Game::display_size_warning() {
-    werase(mainWindow);
-
-    attron(A_BOLD);
-    box(mainWindow, 0, 0);
-    std::string warning = "WARNING: Terminal size too small!";
-    mvwprintw(mainWindow, height / 2, width / 2 - warning.length() / 2, warning.c_str());
-    attroff(A_BOLD);
-    wrefresh(mainWindow);
+     int term_h, term_w;
+     getmaxyx(stdscr, term_h, term_w);
+     erase();
+     mvprintw(term_h / 2 - 1, (term_w - 35) / 2, "Terminal too small. Please resize.");
+     mvprintw(term_h / 2, (term_w - 42) / 2, "Requires at least %d height and %d width.", MIN_HEIGHT, MIN_WIDTH);
+     refresh();
 }
 
 bool Game::checkSize() {
     int newHeight, newWidth;
     getmaxyx(stdscr, newHeight, newWidth);
-    height = newHeight;
-    width = newWidth;
-    return (newHeight >= MIN_HEIGHT && newWidth >= MIN_WIDTH);
+
+    if (newHeight < MIN_HEIGHT || newWidth < MIN_WIDTH) {
+        return false; // Size is too small = return false
+    }
+
+    // Only update if size actually changed and is valid
+    if (newHeight != height || newWidth != width) {
+        height = newHeight;
+        width = newWidth;
+
+        // Resize the window
+        wresize(mainWindow, height, width);
+
+        // Re-draw necessary elements after resize
+        werase(mainWindow);
+        box(mainWindow, 0, 0);
+    }
+    return true; // Size is okay = return true
 }
 
 void Game::waitForResize() {
+    display_size_warning();
+    int ch;
+    nodelay(stdscr, TRUE);
+    while ((ch = getch()) != ERR) { ; }
+    nodelay(stdscr, FALSE);
+
+    // Loop until the size is adequate
     while (!checkSize()) {
-        display_size_warning();
+        // Check for resize event without blocking (optional but better UX)
+        napms(100);
     }
+    clear();
+    refresh();
+
+    // Ensure the mainWindow is ready for drawing after resize
+    keypad(mainWindow, TRUE);
+    touchwin(mainWindow);
+    wrefresh(mainWindow);
 }
 
-void Game::newGame() {
-    displayContent("Starting a new game. Press any key to return to menu.");
-    // Gameplay logic all handled by startGame class
+void Game::newGame(int difficulty) {
+    std::string diff_str;
+    switch(difficulty) {
+        case 0: diff_str = "Easy"; break;
+        case 1: diff_str = "Medium"; break;
+        case 2: diff_str = "Hard"; break;
+        default: diff_str = "Unknown"; break;
+    }
+    displayContent("Starting a new game on " + diff_str + " difficulty... (Gameplay TBD)");
+    // TODO: Initialize game state based on difficulty (map size, packages, etc.)
+    // TODO: Enter the actual game loop here (or elsewhere, I might be reconstructing it soon)
+    current_state = GameState::MAIN_MENU; // Return to main menu for now
 }
+
+// I am still thinking if we have to add a load function or not, personally I think it is not needed
+// but I will leave it here for now, just in case we need it later
+// I suggest changing this "load" to Stats, where players can see their stats when selecting it
 
 void Game::load() {
-    displayContent("Loading game. Press any key to return to menu.");
-    // Load game logic handled by load class
+    displayContent("Loading game... (Not implemented)");
+    // TODO: Implement loading logic from a save file
+    current_state = GameState::MAIN_MENU; // Return to main menu
 }
+
+// Main Game Loop
 
 void Game::run() {
     int choice;
 
-    while (true) {
+    while (current_state != GameState::EXITING) { // Loop until exit state
+        // Size Check
         if (!checkSize()) {
             waitForResize();
+            // After resize, the loop continues and redraws the correct menu
+            continue; // Skip the rest of the loop iteration to redraw immediately
         }
 
-        displayMenu();
-        choice = getch();
-
-        switch (choice) {
-            case KEY_UP:
-                menuHighlight = (menuHighlight > 0) ? menuHighlight - 1 : menuItems.size() - 1;
+        // Display based on State
+        switch (current_state) {
+            case GameState::MAIN_MENU:
+                displayMenu();
                 break;
-            case KEY_DOWN:
-                menuHighlight = (menuHighlight < menuItems.size() - 1) ? menuHighlight + 1 : 0;
+            case GameState::DIFFICULTY_SELECT:
+                displayDifficultyMenu();
                 break;
-            case '\n':
-                switch (menuHighlight) {
-                    case 0:
-                        newGame();
-                        break;
-                    case 1:
-                        load();
-                        break;
-                    case 2:
-                        return;
-                }
-                break;
+            // Add cases for IN_GAME, GAME_OVER etc. later
+            default:
+                 // Shouldn't happen but just in case
+                 displayContent("Error: Unknown game state!");
+                 current_state = GameState::MAIN_MENU; // Recover to main menu
+                 break;
         }
+
+        // Input Handling
+        choice = wgetch(mainWindow); // Get input
+
+        // State-Specific Input Processing
+        switch (current_state) {
+            case GameState::MAIN_MENU:
+                handleMainMenuInput(choice);
+                break;
+            case GameState::DIFFICULTY_SELECT:
+                handleDifficultyInput(choice);
+                break;
+            // Add cases for other states
+        }
+
+        // Handle Global Events (like resize)
+        if (choice == KEY_RESIZE) {
+             // Size check is handled at the start of the loop.
+             touchwin(mainWindow);
+        }
+    }
+}
+
+// Input Handlers
+
+void Game::handleMainMenuInput(int choice) {
+    switch (choice) {
+        case KEY_UP:
+            menuHighlight = (menuHighlight - 1 + menuItems.size()) % menuItems.size();
+            break;
+        case KEY_DOWN:
+            menuHighlight = (menuHighlight + 1) % menuItems.size();
+            break;
+        case '\n':
+        case KEY_ENTER:
+            if (menuHighlight == 0) { // "Start" selected
+                current_state = GameState::DIFFICULTY_SELECT;
+                difficultyHighlight = 0; // Reset difficulty selection highlight
+            } else if (menuHighlight == 1) { // "Load" selected
+                load(); // Stays in MAIN_MENU state after load placeholder
+            } else if (menuHighlight == 2) { // "Exit" selected
+                current_state = GameState::EXITING;
+            }
+            break;
+        // KEY_RESIZE is handled globally in run()
+        default:
+            break;
+    }
+}
+
+void Game::handleDifficultyInput(int choice) {
+     switch (choice) {
+        case KEY_UP:
+            difficultyHighlight = (difficultyHighlight - 1 + difficultyItems.size()) % difficultyItems.size();
+            break;
+        case KEY_DOWN:
+            difficultyHighlight = (difficultyHighlight + 1) % difficultyItems.size();
+            break;
+        case '\n':
+        case KEY_ENTER:
+            // Pass the selected difficulty index (0=Easy, 1=Medium, 2=Hard)
+            newGame(difficultyHighlight);
+            // newGame currently sets state back to MAIN_MENU.
+            // Later, it will set state to IN_GAME.
+            break;
+        case 27: // ESC
+        case KEY_BACKSPACE: // Often mapped similarly or preferred by users
+             current_state = GameState::MAIN_MENU; // Go back to main menu
+             menuHighlight = 0;
+             break;
+        // KEY_RESIZE is handled globally in run()
+        default:
+            break;
     }
 }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -10,7 +10,7 @@ const int MIN_HEIGHT = 25;
 const int MIN_WIDTH = 80;
 
 // Constructor initializes ncurses and create main window
-Game::Game() : menuHighlight(0), menuItems{"Start", "Load", "Exit"}, current_state(GameState::MAIN_MENU), difficultyHighlight(0), difficultyItems{"Easy", "Medium", "Hard"} {
+Game::Game() : menuHighlight(0), menuItems{"Start", "Stats", "Exit"}, current_state(GameState::MAIN_MENU), difficultyHighlight(0), difficultyItems{"Easy", "Medium", "Hard"} {
     initscr();             // Initialize ncurses
     cbreak();              // Disable line buffering
     noecho();              // Don't show input
@@ -86,6 +86,8 @@ void Game::displayMenu() {
     mvwprintw(mainWindow, rightY++, descX, " ");
     mvwprintw(mainWindow, rightY++, descX, "Select 'Start' to begin");
     mvwprintw(mainWindow, rightY++, descX, "your perilous journey.");
+    mvwprintw(mainWindow, rightY++, descX, "Select 'Stats' to view");
+    mvwprintw(mainWindow, rightY++, descX, "your past performance.");
     mvwprintw(mainWindow, rightY++, descX, "-------------------------");
     wattroff(mainWindow, COLOR_PAIR(2));
 
@@ -239,13 +241,11 @@ void Game::newGame(int difficulty) {
     current_state = GameState::MAIN_MENU; // Return to main menu for now
 }
 
-// I am still thinking if we have to add a load function or not, personally I think it is not needed
-// but I will leave it here for now, just in case we need it later
-// I suggest changing this "load" to Stats, where players can see their stats when selecting it
-
-void Game::load() {
-    displayContent("Loading game... (Not implemented)");
-    // TODO: Implement loading logic from a save file
+void Game::displayStats() {
+    displayContent("Displaying Stats... (Not implemented)");
+    // TODO: Implement stats display logic
+    // For now, just show a message and wait for input to return
+    wgetch(mainWindow); // Wait for key press before returning
     current_state = GameState::MAIN_MENU; // Return to main menu
 }
 
@@ -270,6 +270,9 @@ void Game::run() {
             case GameState::DIFFICULTY_SELECT:
                 displayDifficultyMenu();
                 break;
+            case GameState::STATS:
+                displayStats();
+                break;
             // Add cases for IN_GAME, GAME_OVER etc. later
             default:
                  // Shouldn't happen but just in case
@@ -278,24 +281,26 @@ void Game::run() {
                  break;
         }
 
-        // Input Handling
-        choice = wgetch(mainWindow); // Get input
+        // Input Handling - Only process input if not already handled by the display function (like displayStats)
+        if (current_state != GameState::STATS) {
+            choice = wgetch(mainWindow); // Get input
 
-        // State-Specific Input Processing
-        switch (current_state) {
-            case GameState::MAIN_MENU:
-                handleMainMenuInput(choice);
-                break;
-            case GameState::DIFFICULTY_SELECT:
-                handleDifficultyInput(choice);
-                break;
-            // Add cases for other states
-        }
+            // State-Specific Input Processing
+            switch (current_state) {
+                case GameState::MAIN_MENU:
+                    handleMainMenuInput(choice);
+                    break;
+                case GameState::DIFFICULTY_SELECT:
+                    handleDifficultyInput(choice);
+                    break;
+                // Add cases for other states
+            }
 
-        // Handle Global Events (like resize)
-        if (choice == KEY_RESIZE) {
-             // Size check is handled at the start of the loop.
-             touchwin(mainWindow);
+            // Handle Global Events (like resize)
+            if (choice == KEY_RESIZE) {
+                 // Size check is handled at the start of the loop.
+                 touchwin(mainWindow);
+            }
         }
     }
 }
@@ -315,8 +320,8 @@ void Game::handleMainMenuInput(int choice) {
             if (menuHighlight == 0) { // "Start" selected
                 current_state = GameState::DIFFICULTY_SELECT;
                 difficultyHighlight = 0; // Reset difficulty selection highlight
-            } else if (menuHighlight == 1) { // "Load" selected
-                load(); // Stays in MAIN_MENU state after load placeholder
+            } else if (menuHighlight == 1) { // "Stats" selected
+                current_state = GameState::STATS;
             } else if (menuHighlight == 2) { // "Exit" selected
                 current_state = GameState::EXITING;
             }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -18,6 +18,9 @@ Game::Game() : menuHighlight(0), menuItems{"Start", "Stats", "Exit"}, current_st
     start_color();         // Enable color usage
     keypad(stdscr, TRUE);  // Enable special keys for stdscr initially
 
+    // Set timeout for ESC key
+    ESCDELAY = 25;
+
     // Initialize color pairs
     init_pair(1, COLOR_YELLOW, COLOR_BLACK);
     init_pair(2, COLOR_CYAN, COLOR_BLACK);
@@ -170,8 +173,7 @@ void Game::displayContent(const std::string& text) {
      werase(mainWindow);
      box(mainWindow, 0, 0);
      mvwprintw(mainWindow, height / 2, (width - text.length()) / 2, "%s", text.c_str());
-     wrefresh(mainWindow);
-     wgetch(mainWindow);
+     wgetch(mainWindow);  // wgetch refreshes window by default
 }
 
 void Game::display_size_warning() {
@@ -245,8 +247,6 @@ void Game::displayStats() {
     displayContent("Displaying Stats... (Not implemented)");
     // TODO: Implement stats display logic
     // For now, just show a message and wait for input to return
-    wgetch(mainWindow); // Wait for key press before returning
-    current_state = GameState::MAIN_MENU; // Return to main menu
 }
 
 // Main Game Loop
@@ -298,9 +298,11 @@ void Game::run() {
 
             // Handle Global Events (like resize)
             if (choice == KEY_RESIZE) {
-                 // Size check is handled at the start of the loop.
-                 touchwin(mainWindow);
+                // Size check is handled at the start of the loop.
+                touchwin(mainWindow);
             }
+        } else {
+            current_state = GameState::MAIN_MENU;
         }
     }
 }


### PR DESCRIPTION
Need more design on this one. Have to go through multiple iterations to get this main menu ready.

---

If you don't have the environment to build the project, navigate to `Actions` and find the corresponding [Build Windows EXE](https://github.com/NaughtyChas/ENGG1340-GP/actions/workflows/buildExe.yml) actions to download artifacts. Usually, the latest file can be downloaded from the latest success run.

Or I have updated Github Actions so you can download the artifact straight from this PR thread.

---

@iForImaginary @WuZijie-prog @Hyper-aceX @ZhaoJiayu-pp @QI-1891 

1. ~~The current version of the main menu consists of these three categories: [Start, Load, Exit] on the first menu layer. I think should we change "Load" into other features, like "Stats" instead? Or we simply delete it？~~

    *Update: Changed `Load` to `Stats`.*

3. The current version of menu looks like no decorations. Are there any artistic design suggestion on it? 
*I've tried ASCII art but our title is too long so looking for a better visual representation scheme.*

4. I may refactor the game logic afterwards, probably in a new PR after this gets merged.