### PR TITLE
fix: add "%s" when using mvwprintw to avoid format warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,3 +184,9 @@ Every time you pass a level, the score will accumulate until game over. Then you
    - **Color Coding**: Different elements use distinct colors for improved readability (packages, player, obstacles, etc.).
    - **Input Handling**: Menu selections, confirmation dialogs, and game elements all respond to player input. Non-blocking input allows real-time time display regardless of user input.
    - **Screen Management**: Handles terminal resizing and ensures minimum size requirements for optimal gameplay.
+
+---
+
+Extra contributions from the community:
+
+Thanks @XTZ206 for applying standard practices for strings!

--- a/src/gameplay.cpp
+++ b/src/gameplay.cpp
@@ -1314,7 +1314,7 @@ void Gameplay::displayStaminaBar() {
 
     // --- Title ---
     const char* title = " Stamina ";
-    mvwprintw(staminaWin, 0, 2, title);
+    mvwprintw(staminaWin, 0, 2, "%s", title);
 
     // --- Bar Calculation ---
     int barWidth = getmaxx(staminaWin) - 4;
@@ -1341,7 +1341,7 @@ void Gameplay::displayStaminaBar() {
     std::string staminaText = std::to_string(currentStamina) + " / " + std::to_string(maxStamina);
     int textX = getmaxx(staminaWin) - 2 - staminaText.length();
     textX = std::max(2, textX);  // Ensure it doesn't overwrite left border
-    mvwprintw(staminaWin, 1, textX, staminaText.c_str());
+    mvwprintw(staminaWin, 1, textX, "%s", staminaText.c_str());
 
     wnoutrefresh(staminaWin);
 }
@@ -1352,7 +1352,7 @@ void Gameplay::displayHistory() {
 
     // --- Title ---
     const char* title = " Gameplay History ";
-    mvwprintw(historyWin, 0, 2, title);
+    mvwprintw(historyWin, 0, 2, "%s", title);
 
     // --- Display Messages ---
     int maxLines = getmaxy(historyWin) - 2;
@@ -1370,7 +1370,7 @@ void Gameplay::displayHistory() {
         if (msg.length() > maxWidth) {
             msg.resize(maxWidth);
         }
-        mvwprintw(historyWin, currentLine++, 2, msg.c_str());
+        mvwprintw(historyWin, currentLine++, 2, "%s", msg.c_str());
     }
 
     // Example placeholder if no messages yet


### PR DESCRIPTION
Currently, there are some mvwprintw used incorrectly (missing "%s") in [gameplay.cpp](https://github.com/NaughtyChas/ENGG1340-GP/blob/master/src/gameplay.cpp), causing format warnings when compiling.
![warning](https://github.com/user-attachments/assets/a64d8130-b10e-447a-a985-b3f605e2ce9f)
